### PR TITLE
Use ParsingContext.Culture instead of CurrentCulture

### DIFF
--- a/src/Irony.Interpreter/Bindings/IBindingSource.cs
+++ b/src/Irony.Interpreter/Bindings/IBindingSource.cs
@@ -26,7 +26,7 @@ namespace Irony.Interpreter {
 
   public class BindingSourceTable : Dictionary<string, IBindingSource>, IBindingSource {
     public BindingSourceTable(bool caseSensitive)
-      : base(caseSensitive ? StringComparer.CurrentCulture : StringComparer.CurrentCultureIgnoreCase) {
+      : base(caseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase) {
     }
     //IBindingSource Members
     public Binding Bind(BindingRequest request) {

--- a/src/Irony.Interpreter/Scopes/SlotInfo.cs
+++ b/src/Irony.Interpreter/Scopes/SlotInfo.cs
@@ -41,7 +41,7 @@ namespace Irony.Interpreter {
 
   public class SlotInfoDictionary : Dictionary<string, SlotInfo> {
     public SlotInfoDictionary(bool caseSensitive)
-      : base(32, caseSensitive ? StringComparer.CurrentCulture : StringComparer.CurrentCultureIgnoreCase) { }
+      : base(32, caseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase) { }
   }
 
 }

--- a/src/Irony/Parsing/Grammar/Grammar.cs
+++ b/src/Irony/Parsing/Grammar/Grammar.cs
@@ -60,7 +60,7 @@ namespace Irony.Parsing {
     
     public string GrammarComments; //shown in Grammar info tab
 
-    public CultureInfo DefaultCulture = CultureInfo.CurrentCulture;
+    public CultureInfo DefaultCulture = CultureInfo.InvariantCulture;
 
     //Console-related properties, initialized in grammar constructor
     public string ConsoleTitle;
@@ -76,8 +76,7 @@ namespace Irony.Parsing {
     public Grammar(bool caseSensitive) {
       _currentGrammar = this;
       this.CaseSensitive = caseSensitive;
-      bool ignoreCase =  !this.CaseSensitive;
-      var stringComparer = ignoreCase ? StringComparer.CurrentCultureIgnoreCase : StringComparer.CurrentCulture;
+      var stringComparer = caseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
 
       KeyTerms = new KeyTermTable(stringComparer);
       //Initialize console attributes

--- a/src/Irony/Parsing/Scanner/SourceStream.cs
+++ b/src/Irony/Parsing/Scanner/SourceStream.cs
@@ -29,7 +29,7 @@ namespace Irony.Parsing {
       _text = text;
       _textLength = _text.Length; 
       _chars = Text.ToCharArray(); 
-      _stringComparison = caseSensitive ? StringComparison.CurrentCulture : StringComparison.CurrentCultureIgnoreCase;
+      _stringComparison = caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
       _tabWidth = tabWidth; 
       _location = initialLocation;
       _previewPosition = _location.Position;

--- a/src/Irony/Parsing/Terminals/CompoundTerminalBase.cs
+++ b/src/Irony/Parsing/Terminals/CompoundTerminalBase.cs
@@ -150,7 +150,7 @@ namespace Irony.Parsing {
       } else {
         ReadSuffix(source, details);
 
-        if(!ConvertValue(details)) {
+        if(!ConvertValue(details, context)) {
           if (string.IsNullOrEmpty(details.Error))
             details.Error = Resources.ErrInvNumber;
           return context.CreateErrorToken(details.Error); // "Failed to convert the value: {0}"
@@ -188,7 +188,7 @@ namespace Irony.Parsing {
     protected virtual void ReadPrefix(ISourceStream source, CompoundTokenDetails details) {
       if (!_prefixesFirsts.Contains(source.PreviewChar))
         return;
-      var comparisonType = CaseSensitivePrefixesSuffixes ? StringComparison.CurrentCulture : StringComparison.CurrentCultureIgnoreCase;
+      var comparisonType = CaseSensitivePrefixesSuffixes ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
       foreach (string pfx in Prefixes) {
         // Prefixes are usually case insensitive, even if language is case-sensitive. So we cannot use source.MatchSymbol here,
         // we need case-specific comparison
@@ -211,7 +211,7 @@ namespace Irony.Parsing {
 
     protected virtual void ReadSuffix(ISourceStream source, CompoundTokenDetails details) {
       if (!_suffixesFirsts.Contains(source.PreviewChar)) return;
-      var comparisonType = CaseSensitivePrefixesSuffixes ? StringComparison.CurrentCulture : StringComparison.CurrentCultureIgnoreCase;
+      var comparisonType = CaseSensitivePrefixesSuffixes ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
       foreach (string sfx in Suffixes) {
         //Suffixes are usually case insensitive, even if language is case-sensitive. So we cannot use source.MatchSymbol here,
         // we need case-specific comparison
@@ -228,7 +228,7 @@ namespace Irony.Parsing {
       }//foreach
     }//method
 
-    protected virtual bool ConvertValue(CompoundTokenDetails details) {
+    protected virtual bool ConvertValue(CompoundTokenDetails details, ParsingContext context) {
       details.Value = details.Body;
       return false; 
     }

--- a/src/Irony/Parsing/Terminals/FreeTextLiteral.cs
+++ b/src/Irony/Parsing/Terminals/FreeTextLiteral.cs
@@ -84,7 +84,7 @@ namespace Irony.Parsing {
     private Token TryMatchContentSimple(ParsingContext context, ISourceStream source) {
       var startPos = source.PreviewPosition;
       var termLen = _singleTerminator.Length;
-      var stringComp = Grammar.CaseSensitive ? StringComparison.CurrentCulture : StringComparison.CurrentCultureIgnoreCase;
+      var stringComp = Grammar.CaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
       int termPos = source.Text.IndexOf(_singleTerminator, startPos, stringComp);
       if (termPos < 0 && IsSet(FreeTextOptions.AllowEof))
         termPos = source.Text.Length;

--- a/src/Irony/Parsing/Terminals/IdentifierTerminal.cs
+++ b/src/Irony/Parsing/Terminals/IdentifierTerminal.cs
@@ -166,7 +166,7 @@ namespace Irony.Parsing {
       //!!! Do not convert to common case (all-lower) for case-insensitive grammar. Let identifiers remain as is, 
       //  it is responsibility of interpreter to provide case-insensitive read/write operations for identifiers
       // if (!this.GrammarData.Grammar.CaseSensitive)
-      //    token.Value = token.Text.ToLower(CultureInfo.CurrentCulture);
+      //    token.Value = token.Text.ToLower(context.Culture);
       CheckReservedWord(token);
       return token; 
     }
@@ -254,7 +254,7 @@ namespace Irony.Parsing {
       return result;
     }
 
-    protected override bool ConvertValue(CompoundTokenDetails details) {
+    protected override bool ConvertValue(CompoundTokenDetails details, ParsingContext context) {
       if (details.IsSet((short)IdOptions.NameIncludesPrefix))
         details.Value = details.Prefix + details.Body;
       else

--- a/src/Irony/Parsing/Terminals/StringLiteral.cs
+++ b/src/Irony/Parsing/Terminals/StringLiteral.cs
@@ -285,7 +285,7 @@ namespace Irony.Parsing {
 
 
     //Extract the string content from lexeme, adjusts the escaped and double-end symbols
-    protected override bool ConvertValue(CompoundTokenDetails details) {
+    protected override bool ConvertValue(CompoundTokenDetails details, ParsingContext context) {
       string value = details.Body;
       bool escapeEnabled = !details.IsSet((short)StringOptions.NoEscapes);
       //Fix all escapes


### PR DESCRIPTION
This is to use `ParsingContext.Culture` anywhere the culture is used, as it was intended by the design.

Users can still use `CultureInfo.CurrentCulture` if they want by setting it on the `ParsingContext` instance.