### PR TITLE
Original unit tests ported to xunit/netcore

### DIFF
--- a/IronyNetCore.sln
+++ b/IronyNetCore.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.12
+VisualStudioVersion = 15.0.27004.2005
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{24CE2713-8206-4C06-9397-7AD757E7D002}"
 	ProjectSection(SolutionItems) = preProject
@@ -14,6 +14,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Irony.Interpreter", "src\Irony.Interpreter\Irony.Interpreter.csproj", "{9C9A9585-F983-4616-BA71-4D51CAC0A7D8}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Irony.SampleApp", "src\Irony.SampleApp\Irony.SampleApp.csproj", "{9F250C38-91EA-4C15-8AAC-AC3D56955EAE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Irony.Tests", "src\Irony.Tests\Irony.Tests.csproj", "{BC3488D4-45EE-47CD-8D7A-A7365F09CD59}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,8 +35,15 @@ Global
 		{9F250C38-91EA-4C15-8AAC-AC3D56955EAE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9F250C38-91EA-4C15-8AAC-AC3D56955EAE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9F250C38-91EA-4C15-8AAC-AC3D56955EAE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BC3488D4-45EE-47CD-8D7A-A7365F09CD59}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BC3488D4-45EE-47CD-8D7A-A7365F09CD59}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BC3488D4-45EE-47CD-8D7A-A7365F09CD59}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BC3488D4-45EE-47CD-8D7A-A7365F09CD59}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {3FBB2DED-F7C5-4EA6-B8D6-50AD8F561D33}
 	EndGlobalSection
 EndGlobal

--- a/src/Irony.Tests/CommentTerminalTests.cs
+++ b/src/Irony.Tests/CommentTerminalTests.cs
@@ -1,0 +1,24 @@
+using Irony.Parsing;
+using Xunit;
+
+namespace Irony.Tests
+{
+    public class CommentTerminalTests
+    {
+        [Fact]
+        public void TestCommentTerminal()
+        {
+            Parser parser; Token token;
+
+            parser = TestHelper.CreateParser(new CommentTerminal("Comment", "/*", "*/"));
+            token = parser.ParseInput("/* abc  */");
+            Assert.True(token.Category == TokenCategory.Comment, "Failed to read comment");
+
+            parser = TestHelper.CreateParser(new CommentTerminal("Comment", "//", "\n"));
+            token = parser.ParseInput("// abc  \n   ");
+            Assert.True(token.Category == TokenCategory.Comment, "Failed to read line comment");
+
+        }//method
+
+    }//class
+}//namespace

--- a/src/Irony.Tests/DataLiteralsTests.cs
+++ b/src/Irony.Tests/DataLiteralsTests.cs
@@ -1,0 +1,54 @@
+﻿using Irony.Parsing;
+using System;
+using Xunit;
+
+namespace Irony.Tests
+{
+
+  public class DataLiteralsTests {
+  
+    [Fact]
+    public void TestDataLiterals() {
+      Parser parser; Token token;
+      Terminal term;
+
+      // FixedLengthLiteral ---------------------------------------------------------
+      term = new FixedLengthLiteral("fixedLengthInteger", 2, TypeCode.Int32);
+      parser = TestHelper.CreateParser(term, null);
+      
+      token = parser.ParseInput("1200");
+      Assert.True(token.Value != null, "Failed to parse fixed-length integer.");
+      Assert.True((int)token.Value == 12, "Failed to parse fixed-length integer - result value does not match.");
+
+      term = new FixedLengthLiteral("fixedLengthString", 2, TypeCode.String);
+      parser = TestHelper.CreateParser(term);
+      token = parser.ParseInput("abcd", useTerminator: false);
+      Assert.True(token != null && token.Value != null, "Failed to parse fixed-length string.");
+      Assert.True((string)token.Value == "ab", "Failed to parse fixed-length string - result value does not match");
+
+      // DsvLiteral ----------------------------------------------------------------
+      term = new DsvLiteral("DsvInteger", TypeCode.Int32, ",");
+      parser = TestHelper.CreateParser(term);
+      token = parser.ParseInput("12,");
+      Assert.True(token != null && token.Value != null, "Failed to parse CSV integer.");
+      Assert.True((int)token.Value == 12, "Failed to parse CSV integer - result value does not match.");
+
+      term = new DsvLiteral("DsvInteger", TypeCode.String, ",");
+      parser = TestHelper.CreateParser(term);
+      token = parser.ParseInput("ab,");
+      Assert.True(token != null && token.Value != null, "Failed to parse CSV string.");
+      Assert.True((string)token.Value == "ab", "Failed to parse CSV string - result value does not match.");
+    
+      // QuotedValueLiteral ----------------------------------------------------------------
+      term = new QuotedValueLiteral ("QVDate", "#", TypeCode.DateTime);
+      parser = TestHelper.CreateParser(term);
+      token = parser.ParseInput("#11/15/2009#");
+      Assert.True(token != null && token.Value != null, "Failed to parse quoted date.");
+      Assert.True((DateTime)token.Value == new DateTime(2009, 11, 15), "Failed to parse quoted date - result value does not match.");
+
+    }//method
+
+
+  }//class
+
+}//namespace

--- a/src/Irony.Tests/ErrorRecoveryTests.cs
+++ b/src/Irony.Tests/ErrorRecoveryTests.cs
@@ -1,0 +1,45 @@
+using Irony.Parsing;
+using Xunit;
+
+namespace Irony.Tests
+{
+    public class ErrorRecoveryTests {
+
+    #region Grammars
+    //A simple grammar for language consisting of simple assignment statements: x=y + z; z= t + m;
+    public class ErrorRecoveryGrammar : Grammar {
+      public ErrorRecoveryGrammar() {
+        var id = new IdentifierTerminal("id");
+        var expr = new NonTerminal("expr");
+        var stmt = new NonTerminal("stmt");
+        var stmtList = new NonTerminal("stmt");
+
+        base.Root = stmtList;
+        stmtList.Rule = MakeStarRule(stmtList, stmt);
+        stmt.Rule = id + "=" + expr + ";";
+        stmt.ErrorRule = SyntaxError + ";";
+        expr.Rule = id | id + "+" + id; 
+      }
+    }// class
+
+    #endregion
+
+    [Fact]
+    public void TestErrorRecovery() {
+
+      var grammar = new ErrorRecoveryGrammar();
+      var parser = new Parser(grammar);
+      TestHelper.CheckGrammarErrors(parser);
+
+      //correct sample
+      var parseTree = parser.Parse("x = y; y = z + m; m = n;");
+      Assert.False(parseTree.HasErrors(), "Unexpected parse errors in correct source sample.");
+
+      parseTree = parser.Parse("x = y; m = = d ; y = z + m; x = z z; m = n;");
+      Assert.True(2 == parseTree.ParserMessages.Count, "Invalid # of errors.");
+
+    }
+
+
+  }//class
+}//namespace

--- a/src/Irony.Tests/EvaluatorTests.cs
+++ b/src/Irony.Tests/EvaluatorTests.cs
@@ -1,0 +1,277 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Irony.Interpreter;
+using Irony.Interpreter.Evaluator;
+using Xunit;
+
+namespace Irony.Tests
+{
+
+    public class EvaluatorTests
+    {
+
+        [Fact]
+        public void TestEvaluator_Ops()
+        {
+            var eval = new ExpressionEvaluator();
+            string script;
+            object result;
+
+            //Simple computation
+            script = "2*3";
+            result = eval.Evaluate(script);
+            Assert.Equal(6, result);
+
+            //Using variables
+            script = @"
+x=2
+y=4
+x * y
+";
+            result = eval.Evaluate(script);
+            Assert.Equal(8, result);
+
+            //Operator precedence
+            script = @"
+x=2
+y=3
+x + y * 5
+";
+            result = eval.Evaluate(script);
+            Assert.Equal(17, result);
+
+            //parenthesis
+            script = @"
+x=3
+y=2
+1 + (x - y) * 5
+";
+            result = eval.Evaluate(script);
+            Assert.Equal(6, result);
+
+            //strings
+            script = @"
+x='2'
+y='3'
+x + y + 4
+";
+            result = eval.Evaluate(script);
+            Assert.Equal("234", result);
+
+            //string with embedded expressions
+            script = @"
+x = 4
+y = 7 
+'#{x} * #{y} = #{x * y}'
+";
+            result = eval.Evaluate(script);
+            Assert.Equal("4 * 7 = 28", result);
+
+            //various operators
+            script = @"
+x = 1 + 2 * 3      # =7
+y = --x            # = 6
+z =  x * 1.5       # = 9
+z -= y             # = 3   
+";
+            result = eval.Evaluate(script);
+            Assert.InRange(3.0 - (double)result, -0.0001, 0.0001);
+
+            //&&, || operators
+            script = @"x = (1 > 0) || (1/0)";
+            result = eval.Evaluate(script);
+            Assert.Equal(true, result);
+
+            //Operator precedence test
+            script = @"2+3*3*3";
+            result = eval.Evaluate(script);
+            Assert.Equal(29, result);
+
+            script = @"x = (1 < 0) && (1/0)";
+            result = eval.Evaluate(script);
+            Assert.Equal(false, result);
+        }
+
+        [Fact]
+        public void TestEvaluator_BuiltIns()
+        {
+            var eval = new ExpressionEvaluator();
+            string script;
+            object result;
+
+            //Using methods imported from System.Math class
+
+            //TODO this generates System.Reflection.AmbiguousMatchException
+            script = @"abs(-1.0) + Log10(100.0) + sqrt(9) + floor(4.5) + sin(PI/2)";
+            result = eval.Evaluate(script);
+            Assert.True(result is double, "Result is not double.");
+            Assert.InRange(11.0 - (double)result, -0.001, 0.001);
+
+            //Using methods imported from System.Environment
+            script = @"report = '#{MachineName}-#{ProcessorCount}'";
+            result = eval.Evaluate(script);
+            var expected = string.Format("{0}-{1}", Environment.MachineName, Environment.ProcessorCount);
+            Assert.Equal(expected, result);
+
+            //Using special built-in methods print and format
+            eval.ClearOutput();
+            script = @"print(format('{0} * {1} = {2}', 3, 4, 3 * 4))";
+            eval.Evaluate(script);
+            result = eval.GetOutput();
+            Assert.Equal("3 * 4 = 12\r\n", result);
+
+            //Add custom built-in method SayHello and test it
+            eval.Runtime.BuiltIns.AddMethod(SayHello, "SayHello", 1, 1, "name");
+            script = @"SayHello('John')";
+            result = eval.Evaluate(script);
+            Assert.Equal("Hello, John!", result);
+        }
+
+        //custom built-in method added to evaluator in Built-in tests
+        public static string SayHello(ScriptThread thread, object[] args)
+        {
+            return "Hello, " + args[0] + "!";
+        }
+
+        [Fact]
+        public void TestEvaluator_Iif()
+        {
+            var eval = new ExpressionEvaluator();
+            string script;
+            object result;
+
+            //Test '? :' operator
+            script = @"1 < 0 ? 1/0 : 'false' "; // Notice that (1/0) is not evaluated
+            result = eval.Evaluate(script);
+            Assert.Equal("false", result);
+
+            //Test iif special form
+            script = @"iif(1 > 0, 'true', 1/0) "; //Notice that (1/0) is not evaluated
+            result = eval.Evaluate(script);
+            Assert.Equal("true", result);
+        }
+
+        [Fact]
+        public void TestEvaluator_MemberAccess()
+        {
+            var eval = new ExpressionEvaluator();
+            eval.Globals["foo"] = new Foo();
+            string script;
+            object result;
+
+            //Test access to field, prop, calling a method
+            script = @"foo.Field + ',' + foo.Prop + ',' + foo.GetStuff()";
+            result = eval.Evaluate(script);
+            Assert.Equal("F,P,S", result);
+
+            script = @"
+foo.Field = 'FF'
+foo.Prop = 'PP'
+R = foo.Field + foo.Prop ";
+            result = eval.Evaluate(script);
+            Assert.Equal("FFPP", result);
+
+            //Test access to indexed properties
+
+            //TODO this generates System.Reflection.AmbiguousMatchException
+            script = @"foo[3]";
+            result = eval.Evaluate(script);
+            Assert.Equal("#3", result);
+
+            //TODO this generates System.Reflection.AmbiguousMatchException
+            script = @"foo['a']";
+            result = eval.Evaluate(script);
+            Assert.Equal("V-a", result);
+
+            // Test with string literal
+            script = @" '0123'.Substring(1) + 'abcd'.Length    ";
+            result = eval.Evaluate(script);
+            Assert.Equal("1234", result);
+        }
+
+        //A class used for member access testing
+        public class Foo
+        {
+            public string Field = "F";
+            public string Prop { get; set; }
+
+            public Foo()
+            {
+                Prop = "P";
+            }
+            public string GetStuff()
+            {
+                return "S";
+            }
+            public string this[int i]
+            {
+                get { return "#" + i; }
+                set { }
+            }
+            public string this[string key]
+            {
+                get { return "V-" + key; }
+                set { }
+            }
+        }
+
+        [Fact]
+        public void TestEvaluator_ArrayDictDataRow()
+        {
+            var eval = new ExpressionEvaluator();
+            //Create an array, a dictionary and a data row and add them to Globals
+            eval.Globals["primes"] = new int[] { 3, 5, 7, 11, 13 };
+            var nums = new Dictionary<string, string>(StringComparer.CurrentCultureIgnoreCase);
+            nums["one"] = "1";
+            nums["two"] = "2";
+            nums["three"] = "3";
+            eval.Globals["nums"] = nums;
+            //var t = new System.Data.DataTable();
+            //t.Columns.Add("Name", typeof(string));
+            //t.Columns.Add("Age", typeof(int));
+            //var row = t.NewRow();
+            var row = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+            row["Name"] = "John";
+            row["Age"] = 30;
+            eval.Globals["row"] = row;
+
+            string script;
+            object result;
+
+            //Test array
+            script = @"primes[3]";
+            result = eval.Evaluate(script);
+            Assert.Equal(11, result);
+            script = @"
+primes[3] = 12345
+primes[3]";
+            result = eval.Evaluate(script);
+            Assert.Equal(12345, result);
+
+            //Test dict
+            script = @"nums['three'] + nums['two'] + nums['one']";
+            result = eval.Evaluate(script);
+            Assert.Equal("321", result);
+            script = @"
+nums['two'] = '22'
+nums['three'] + nums['two'] + nums['one']
+";
+            result = eval.Evaluate(script);
+            Assert.Equal("3221", result);
+
+            //Test data row
+            script = @"row['Name'] + ', ' + row['age']";
+            result = eval.Evaluate(script);
+            Assert.Equal("John, 30", result);
+            script = @"
+row['Name'] = 'Jon'
+row['Name'] + ', ' + row['age']";
+            result = eval.Evaluate(script);
+            Assert.Equal("Jon, 30", result);
+        }
+
+
+    }//class
+}//namespace

--- a/src/Irony.Tests/FreeTextLiteralTests.cs
+++ b/src/Irony.Tests/FreeTextLiteralTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Irony.Parsing;
+using Xunit;
+
+namespace Irony.Tests
+{
+
+    public class FreeTextLiteralTests
+    {
+        //A special grammar that does not skip whitespace
+        class FreeTextLiteralTestGrammar : Grammar
+        {
+            public string Terminator = "END";
+            public FreeTextLiteralTestGrammar(Terminal terminal)
+              : base(caseSensitive: true)
+            {
+                var rule = new BnfExpression(terminal);
+                MarkReservedWords(Terminator);
+                rule += Terminator;
+                base.Root = new NonTerminal("Root");
+                Root.Rule = rule;
+            }
+
+            //Overrides base method, effectively suppressing skipping whitespaces
+            public override void SkipWhitespace(ISourceStream source)
+            {
+                return;
+            }
+        }//class
+
+        private Parser CreateParser(Terminal terminal)
+        {
+            var grammar = new FreeTextLiteralTestGrammar(terminal);
+            return new Parser(grammar);
+        }
+        private Token GetFirst(ParseTree tree)
+        {
+            return tree.Tokens[0];
+        }
+
+        //The following test method and a fix are contributed by ashmind codeplex user
+        [Fact]
+        public void TestFreeTextLiteral_Escapes()
+        {
+            Parser parser; Token token;
+
+            //Escapes test
+            var term = new FreeTextLiteral("FreeText", ",", ")");
+            term.Escapes.Add(@"\\", @"\");
+            term.Escapes.Add(@"\,", @",");
+            term.Escapes.Add(@"\)", @")");
+
+            parser = this.CreateParser(term);
+            token = GetFirst(parser.Parse(@"abc\\de\,\)fg,"));
+            Assert.False(token == null, "Failed to produce a token on valid string.");
+            Assert.True(term == token.Terminal, "Failed to scan a string - invalid Terminal in the returned token.");
+            Assert.True(token.Value.ToString() == @"abc\de,)fg", "Failed to scan a string");
+
+            term = new FreeTextLiteral("FreeText", FreeTextOptions.AllowEof, ";");
+            parser = this.CreateParser(term);
+            token = GetFirst(parser.Parse(@"abcdefg"));
+            Assert.False(token == null, "Failed to produce a token for free text ending at EOF.");
+            Assert.True(term == token.Terminal, "Failed to scan a free text ending at EOF - invalid Terminal in the returned token.");
+            Assert.True(token.Value.ToString() == @"abcdefg", "Failed to scan a free text ending at EOF");
+
+            //The following test method and a fix are contributed by ashmind codeplex user
+            //VAR
+            //MESSAGE:STRING80;
+            //(*_ORError Message*)
+            //END_VAR
+            term = new FreeTextLiteral("varContent", "END_VAR");
+            term.Firsts.Add("VAR");
+            parser = this.CreateParser(term);
+            token = GetFirst(parser.Parse("VAR\r\nMESSAGE:STRING80;\r\n(*_ORError Message*)\r\nEND_VAR"));
+            Assert.False(token == null, "Failed to produce a token on valid string.");
+            Assert.True(term == token.Terminal, "Failed to scan a string - invalid Terminal in the returned token.");
+            Assert.True(token.ValueString == "\r\nMESSAGE:STRING80;\r\n(*_ORError Message*)\r\n", "Failed to scan a string");
+
+            term = new FreeTextLiteral("freeText", FreeTextOptions.AllowEof);
+            parser = this.CreateParser(term);
+            token = GetFirst(parser.Parse(" "));
+            Assert.False(token == null, "Failed to produce a token on valid string.");
+            Assert.True(term == token.Terminal, "Failed to scan a string - invalid Terminal in the returned token.");
+            Assert.True(token.ValueString == " ", "Failed to scan a string");
+        }
+
+    }//class
+}//namespace

--- a/src/Irony.Tests/IdentifierTerminalTests.cs
+++ b/src/Irony.Tests/IdentifierTerminalTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Irony.Parsing;
+using Xunit;
+
+namespace Irony.Tests
+{
+    public class IdentifierTerminalTests
+    {
+
+        [Fact]
+        public void TestIdentifier_CSharp()
+        {
+            Parser parser; Token token;
+
+            parser = TestHelper.CreateParser(TerminalFactory.CreateCSharpIdentifier("Identifier"));
+            token = parser.ParseInput("x ");
+            Assert.True(token.Terminal.Name == "Identifier", "Failed to parse identifier");
+            Assert.True((string)token.Value == "x", "Failed to parse identifier");
+            token = parser.ParseInput("_a01 ");
+            Assert.True(token.Terminal.Name == "Identifier", "Failed to parse identifier starting with _");
+            Assert.True((string)token.Value == "_a01", "Failed to parse identifier starting with _");
+
+            token = parser.ParseInput("0abc ");
+            Assert.True(token.IsError(), "Erroneously recognized an identifier.");
+
+            token = parser.ParseInput(@"_\u0061bc ");
+            Assert.True(token.Terminal.Name == "Identifier", "Failed to parse identifier starting with _");
+            Assert.True((string)token.Value == "_abc", "Failed to parse identifier containing escape sequence \\u");
+
+            token = parser.ParseInput(@"a\U00000062c_ ");
+            Assert.True(token.Terminal.Name == "Identifier", "Failed to parse identifier starting with _");
+            Assert.True((string)token.Value == "abc_", "Failed to parse identifier containing escape sequence \\U");
+        }//method
+
+        [Fact]
+        public void TestIdentifier_CaseRestrictions()
+        {
+            Parser parser; Token token;
+
+            var id = new IdentifierTerminal("identifier");
+            id.CaseRestriction = CaseRestriction.None;
+            parser = TestHelper.CreateParser(id);
+
+            token = parser.ParseInput("aAbB");
+            Assert.True(token != null, "Failed to scan an identifier aAbB.");
+
+            id.CaseRestriction = CaseRestriction.FirstLower;
+            parser = TestHelper.CreateParser(id);
+            token = parser.ParseInput("BCD");
+            Assert.True(token.IsError(), "Erroneously recognized an identifier BCD with FirstLower restriction.");
+            token = parser.ParseInput("bCd ");
+            Assert.True(token != null && token.ValueString == "bCd", "Failed to scan identifier bCd with FirstLower restriction.");
+
+            id.CaseRestriction = CaseRestriction.FirstUpper;
+            parser = TestHelper.CreateParser(id);
+            token = parser.ParseInput("cDE");
+            Assert.True(TokenCategory.Error == token.Category, "Erroneously recognized an identifier cDE with FirstUpper restriction.");
+            token = parser.ParseInput("CdE");
+            Assert.True(token != null && token.ValueString == "CdE", "Failed to scan identifier CdE with FirstUpper restriction.");
+
+            id.CaseRestriction = CaseRestriction.AllLower;
+            parser = TestHelper.CreateParser(id);
+            token = parser.ParseInput("DeF");
+            Assert.True(token.IsError(), "Erroneously recognized an identifier DeF with AllLower restriction.");
+            token = parser.ParseInput("def");
+            Assert.True(token != null && token.ValueString == "def", "Failed to scan identifier def with AllLower restriction.");
+
+            id.CaseRestriction = CaseRestriction.AllUpper;
+            parser = TestHelper.CreateParser(id);
+            token = parser.ParseInput("EFg ");
+            Assert.True(token.IsError(), "Erroneously recognized an identifier EFg with AllUpper restriction.");
+            token = parser.ParseInput("EFG");
+            Assert.True(token != null && token.ValueString == "EFG", "Failed to scan identifier EFG with AllUpper restriction.");
+        }//method
+
+
+    }//class
+}//namespace
+
+

--- a/src/Irony.Tests/Irony.Tests.csproj
+++ b/src/Irony.Tests/Irony.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Irony.Interpreter\Irony.Interpreter.csproj" />
+    <ProjectReference Include="..\Irony\Irony.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Irony.Tests/LineContinuationTests.cs
+++ b/src/Irony.Tests/LineContinuationTests.cs
@@ -1,0 +1,54 @@
+using Irony.Parsing;
+using Xunit;
+
+namespace Irony.Tests
+{
+    public class LineContinuationTests {
+
+    [Fact]
+    public void TestContinuationTerminal_Simple() {
+      Parser parser; Token token;
+
+      parser = TestHelper.CreateParser(new LineContinuationTerminal("LineContinuation", "\\"));
+      token = parser.ParseInput("\\\r\t");
+      Assert.True(token.Category == TokenCategory.Outline, "Failed to read simple line continuation terminal");
+    }
+
+    [Fact]
+    public void TestContinuationTerminal_Default() {
+      Parser parser; Token token;
+
+      parser = TestHelper.CreateParser(new LineContinuationTerminal("LineContinuation"));
+      token = parser.ParseInput("_\r\n\t");
+      Assert.True(token.Category == TokenCategory.Outline, "Failed to read default line continuation terminal");
+
+      token = parser.ParseInput("\\\v    ");
+      Assert.True(token.Category == TokenCategory.Outline, "Failed to read default line continuation terminal");
+    }
+
+    [Fact]
+    public void TestContinuationTerminal_Complex() {
+      Parser parser; Token token;
+
+      parser = TestHelper.CreateParser(new LineContinuationTerminal("LineContinuation", @"\continue", @"\cont", "++CONTINUE++"));
+      token = parser.ParseInput("\\cont   \r\n    ");
+      Assert.True(token.Category == TokenCategory.Outline, "Failed to read complex line continuation terminal");
+
+      token = parser.ParseInput("++CONTINUE++\t\v");
+      Assert.True(token.Category == TokenCategory.Outline, "Failed to read complex line continuation terminal");
+    }
+
+    [Fact]
+    public void TestContinuationTerminal_Incomplete() {
+      Parser parser; Token token;
+
+      parser = TestHelper.CreateParser(new LineContinuationTerminal("LineContinuation"));
+      token = parser.ParseInput("\\   garbage");
+      Assert.True(token.Category == TokenCategory.Error, "Failed to read incomplete line continuation terminal");
+
+      parser = TestHelper.CreateParser(new LineContinuationTerminal("LineContinuation"));
+      token = parser.ParseInput("_");
+      Assert.True(token.Category == TokenCategory.Error, "Failed to read incomplete line continuation terminal");
+    }
+  }
+}

--- a/src/Irony.Tests/NumberLiteralTests.cs
+++ b/src/Irony.Tests/NumberLiteralTests.cs
@@ -1,0 +1,406 @@
+//Authors: Roman Ivantsov, Philipp Serr
+
+using Irony.Parsing;
+using System;
+using Xunit;
+
+namespace Irony.Tests
+{
+
+    public class NumberLiteralTests
+    {
+
+        [Fact]
+        public void TestNumber_General()
+        {
+            Parser parser; Token token;
+
+            NumberLiteral number = new NumberLiteral("Number");
+            number.DefaultIntTypes = new TypeCode[] { TypeCode.Int32, TypeCode.Int64, NumberLiteral.TypeCodeBigInt };
+            parser = TestHelper.CreateParser(number);
+            token = parser.ParseInput("123");
+            CheckType(token, typeof(int));
+            Assert.True((int)token.Value == 123, "Failed to read int value");
+            token = parser.ParseInput("123.4");
+            Assert.True(Math.Abs(Convert.ToDouble(token.Value) - 123.4) < 0.000001, "Failed to read float value");
+            //100 digits
+            string sbig = "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890";
+            token = parser.ParseInput(sbig);
+            Assert.True(token.Value.ToString() == sbig, "Failed to read big integer value");
+        }//method
+
+        //The following "sign" test methods and a fix are contributed by ashmind codeplex user
+        [Fact]
+        public void TestNumber_SignedDoesNotMatchSingleMinus()
+        {
+            Parser parser; Token token;
+
+            var number = new NumberLiteral("number", NumberOptions.AllowSign);
+            parser = TestHelper.CreateParser(number);
+            token = parser.ParseInput("-");
+            Assert.True(token.IsError(), "Parsed single '-' as a number value.");
+        }
+
+        [Fact]
+        public void TestNumber_SignedDoesNotMatchSinglePlus()
+        {
+            Parser parser; Token token;
+
+            var number = new NumberLiteral("number", NumberOptions.AllowSign);
+            parser = TestHelper.CreateParser(number);
+            token = parser.ParseInput("+");
+            Assert.True(token.IsError(), "Parsed single '+' as a number value.");
+        }
+
+        [Fact]
+        public void TestNumber_SignedMatchesNegativeCorrectly()
+        {
+            Parser parser; Token token;
+
+            var number = new NumberLiteral("number", NumberOptions.AllowSign);
+            parser = TestHelper.CreateParser(number);
+            token = parser.ParseInput("-500");
+            Assert.Equal(-500, token.Value);
+        }
+
+        [Fact]
+        public void TestNumber_CSharp()
+        {
+            Parser parser; Token token;
+
+            double eps = 0.0001;
+            parser = TestHelper.CreateParser(TerminalFactory.CreateCSharpNumber("Number"));
+
+            //Simple integers and suffixes
+            token = parser.ParseInput("123 ");
+            CheckType(token, typeof(int));
+            Assert.True(token.Details != null, "ScanDetails object not found in token.");
+            Assert.True((int)token.Value == 123, "Failed to read int value");
+
+            token = parser.ParseInput(Int32.MaxValue.ToString());
+            CheckType(token, typeof(int));
+            Assert.True((int)token.Value == Int32.MaxValue, "Failed to read Int32.MaxValue.");
+
+            token = parser.ParseInput(UInt64.MaxValue.ToString());
+            CheckType(token, typeof(ulong));
+            Assert.True((ulong)token.Value == UInt64.MaxValue, "Failed to read uint64.MaxValue value");
+
+            token = parser.ParseInput("123U ");
+            CheckType(token, typeof(UInt32));
+            Assert.True((UInt32)token.Value == 123, "Failed to read uint value");
+
+            token = parser.ParseInput("123L ");
+            CheckType(token, typeof(long));
+            Assert.True((long)token.Value == 123, "Failed to read long value");
+
+            token = parser.ParseInput("123uL ");
+            CheckType(token, typeof(ulong));
+            Assert.True((ulong)token.Value == 123, "Failed to read ulong value");
+
+            //Hex representation
+            token = parser.ParseInput("0x012 ");
+            CheckType(token, typeof(Int32));
+            Assert.True((Int32)token.Value == 0x012, "Failed to read hex int value");
+
+            token = parser.ParseInput("0x12U ");
+            CheckType(token, typeof(UInt32));
+            Assert.True((UInt32)token.Value == 0x012, "Failed to read hex uint value");
+
+            token = parser.ParseInput("0x012L ");
+            CheckType(token, typeof(long));
+            Assert.True((long)token.Value == 0x012, "Failed to read hex long value");
+
+            token = parser.ParseInput("0x012uL ");
+            CheckType(token, typeof(ulong));
+            Assert.True((ulong)token.Value == 0x012, "Failed to read hex ulong value");
+
+            //Floating point types
+            token = parser.ParseInput("123.4 ");
+            CheckType(token, typeof(double));
+            Assert.True(Math.Abs((double)token.Value - 123.4) < eps, "Failed to read double value #1");
+
+            token = parser.ParseInput("1234e-1 ");
+            CheckType(token, typeof(double));
+            Assert.True(Math.Abs((double)token.Value - 1234e-1) < eps, "Failed to read double value #2");
+
+            token = parser.ParseInput("12.34e+01 ");
+            CheckType(token, typeof(double));
+            Assert.True(Math.Abs((double)token.Value - 123.4) < eps, "Failed to read double value  #3");
+
+            token = parser.ParseInput("0.1234E3 ");
+            CheckType(token, typeof(double));
+            Assert.True(Math.Abs((double)token.Value - 123.4) < eps, "Failed to read double value  #4");
+
+            token = parser.ParseInput("123.4f ");
+            CheckType(token, typeof(float));
+            Assert.True(Math.Abs((Single)token.Value - 123.4) < eps, "Failed to read float(single) value");
+
+            token = parser.ParseInput("123.4m ");
+            CheckType(token, typeof(decimal));
+            Assert.True(Math.Abs((decimal)token.Value - 123.4m) < Convert.ToDecimal(eps), "Failed to read decimal value");
+
+            token = parser.ParseInput("123. ", useTerminator: false); //should ignore dot and read number as int. compare it to python numbers - see below
+            CheckType(token, typeof(int));
+            Assert.True((int)token.Value == 123, "Failed to read int value with trailing dot");
+
+            //Quick parse
+            token = parser.ParseInput("1 ");
+            CheckType(token, typeof(int));
+            //When going through quick parse path (for one-digit numbers), the NumberScanInfo record is not created and hence is absent in Attributes
+            Assert.True(token.Details == null, "Quick parse test failed: ScanDetails object is found in token - quick parse path should not produce this object.");
+            Assert.True((int)token.Value == 1, "Failed to read quick-parse value");
+        }
+
+        [Fact]
+        public void TestNumber_VB()
+        {
+            Parser parser; Token token;
+
+            double eps = 0.0001;
+            parser = TestHelper.CreateParser(TerminalFactory.CreateVbNumber("Number"));
+
+            //Simple integer
+            token = parser.ParseInput("123 ");
+            CheckType(token, typeof(int));
+            Assert.True(token.Details != null, "ScanDetails object not found in token.");
+            Assert.True((int)token.Value == 123, "Failed to read int value");
+
+            //Test all suffixes
+            token = parser.ParseInput("123S ");
+            CheckType(token, typeof(Int16));
+            Assert.True((Int16)token.Value == 123, "Failed to read short value");
+
+            token = parser.ParseInput("123I ");
+            CheckType(token, typeof(Int32));
+            Assert.True((Int32)token.Value == 123, "Failed to read int value");
+
+            token = parser.ParseInput("123% ");
+            CheckType(token, typeof(Int32));
+            Assert.True((Int32)token.Value == 123, "Failed to read int value");
+
+            token = parser.ParseInput("123L ");
+            CheckType(token, typeof(long));
+            Assert.True((long)token.Value == 123, "Failed to read long value");
+
+            token = parser.ParseInput("123& ");
+            CheckType(token, typeof(Int64));
+            Assert.True((Int64)token.Value == 123, "Failed to read long value");
+
+            token = parser.ParseInput("123us ");
+            CheckType(token, typeof(UInt16));
+            Assert.True((UInt16)token.Value == 123, "Failed to read ushort value");
+
+            token = parser.ParseInput("123ui ");
+            CheckType(token, typeof(UInt32));
+            Assert.True((UInt32)token.Value == 123, "Failed to read uint value");
+
+            token = parser.ParseInput("123ul ");
+            CheckType(token, typeof(ulong));
+            Assert.True((ulong)token.Value == 123, "Failed to read ulong value");
+
+            //Hex and octal 
+            token = parser.ParseInput("&H012 ");
+            CheckType(token, typeof(int));
+            Assert.True((int)token.Value == 0x012, "Failed to read hex int value");
+
+            token = parser.ParseInput("&H012L ");
+            CheckType(token, typeof(long));
+            Assert.True((long)token.Value == 0x012, "Failed to read hex long value");
+
+            token = parser.ParseInput("&O012 ");
+            CheckType(token, typeof(int));
+            Assert.True((int)token.Value == 10, "Failed to read octal int value"); //12(oct) = 10(dec)
+
+            token = parser.ParseInput("&o012L ");
+            CheckType(token, typeof(long));
+            Assert.True((long)token.Value == 10, "Failed to read octal long value");
+
+            //Floating point types
+            token = parser.ParseInput("123.4 ");
+            CheckType(token, typeof(double));
+            Assert.True(Math.Abs((double)token.Value - 123.4) < eps, "Failed to read double value #1");
+
+            token = parser.ParseInput("1234e-1 ");
+            CheckType(token, typeof(double));
+            Assert.True(Math.Abs((double)token.Value - 1234e-1) < eps, "Failed to read double value #2");
+
+            token = parser.ParseInput("12.34e+01 ");
+            CheckType(token, typeof(double));
+            Assert.True(Math.Abs((double)token.Value - 123.4) < eps, "Failed to read double value  #3");
+
+            token = parser.ParseInput("0.1234E3 ");
+            CheckType(token, typeof(double));
+            Assert.True(Math.Abs((double)token.Value - 123.4) < eps, "Failed to read double value  #4");
+
+            token = parser.ParseInput("123.4R ");
+            CheckType(token, typeof(double));
+            Assert.True(Math.Abs((double)token.Value - 123.4) < eps, "Failed to read double value #5");
+
+            token = parser.ParseInput("123.4# ");
+            CheckType(token, typeof(double));
+            Assert.True(Math.Abs((double)token.Value - 123.4) < eps, "Failed to read double value #6");
+
+            token = parser.ParseInput("123.4f ");
+            CheckType(token, typeof(float));
+            Assert.True(Math.Abs((Single)token.Value - 123.4) < eps, "Failed to read float(single) value");
+
+            token = parser.ParseInput("123.4! ");
+            CheckType(token, typeof(float));
+            Assert.True(Math.Abs((Single)token.Value - 123.4) < eps, "Failed to read float(single) value");
+
+            token = parser.ParseInput("123.4D ");
+            CheckType(token, typeof(decimal));
+            Assert.True(Math.Abs((decimal)token.Value - 123.4m) < Convert.ToDecimal(eps), "Failed to read decimal value");
+
+            token = parser.ParseInput("123.4@ ");
+            CheckType(token, typeof(decimal));
+            Assert.True(Math.Abs((decimal)token.Value - 123.4m) < Convert.ToDecimal(eps), "Failed to read decimal value");
+
+            //Quick parse
+            token = parser.ParseInput("1 ");
+            CheckType(token, typeof(int));
+            //When going through quick parse path (for one-digit numbers), the NumberScanInfo record is not created and hence is absent in Attributes
+            Assert.True(token.Details == null, "Quick parse test failed: ScanDetails object is found in token - quick parse path should not produce this object.");
+            Assert.True((int)token.Value == 1, "Failed to read quick-parse value");
+        }
+
+
+        [Fact]
+        public void TestNumber_Python()
+        {
+            Parser parser; Token token;
+
+            double eps = 0.0001;
+            parser = TestHelper.CreateParser(TerminalFactory.CreatePythonNumber("Number"));
+
+            //Simple integers and suffixes
+            token = parser.ParseInput("123 ");
+            CheckType(token, typeof(int));
+            Assert.True(token.Details != null, "ScanDetails object not found in token.");
+            Assert.True((int)token.Value == 123, "Failed to read int value");
+
+            token = parser.ParseInput("123L ");
+            CheckType(token, typeof(long));
+            Assert.True((long)token.Value == 123, "Failed to read long value");
+
+            //Hex representation
+            token = parser.ParseInput("0x012 ");
+            CheckType(token, typeof(int));
+            Assert.True((int)token.Value == 0x012, "Failed to read hex int value");
+
+            token = parser.ParseInput("0x012l "); //with small "L"
+            CheckType(token, typeof(long));
+            Assert.True((long)token.Value == 0x012, "Failed to read hex long value");
+
+            //Floating point types
+            token = parser.ParseInput("123.4 ");
+            CheckType(token, typeof(double));
+            Assert.True(Math.Abs((double)token.Value - 123.4) < eps, "Failed to read double value #1");
+
+            token = parser.ParseInput("1234e-1 ");
+            CheckType(token, typeof(double));
+            Assert.True(Math.Abs((double)token.Value - 1234e-1) < eps, "Failed to read double value #2");
+
+            token = parser.ParseInput("12.34e+01 ");
+            CheckType(token, typeof(double));
+            Assert.True(Math.Abs((double)token.Value - 123.4) < eps, "Failed to read double value  #3");
+
+            token = parser.ParseInput("0.1234E3 ");
+            CheckType(token, typeof(double));
+            Assert.True(Math.Abs((double)token.Value - 123.4) < eps, "Failed to read double value  #4");
+
+            token = parser.ParseInput(".1234 ");
+            CheckType(token, typeof(double));
+            Assert.True(Math.Abs((double)token.Value - 0.1234) < eps, "Failed to read double value with leading dot");
+
+            token = parser.ParseInput("123. ");
+            CheckType(token, typeof(double));
+            Assert.True(Math.Abs((double)token.Value - 123.0) < eps, "Failed to read double value with trailing dot");
+
+            //Big integer
+            string sbig = "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"; //100 digits
+            token = parser.ParseInput(sbig);
+            Assert.True(token.Value.ToString() == sbig, "Failed to read big integer value");
+
+            //Quick parse
+            token = parser.ParseInput("1 ");
+            CheckType(token, typeof(int));
+            Assert.True(token.Details == null, "Quick parse test failed: ScanDetails object is found in token - quick parse path should produce this object.");
+            Assert.True((int)token.Value == 1, "Failed to read quick-parse value");
+
+        }
+
+        [Fact]
+        public void TestNumber_Scheme()
+        {
+            Parser parser; Token token;
+
+            double eps = 0.0001;
+            parser = TestHelper.CreateParser(TerminalFactory.CreateSchemeNumber("Number"));
+
+
+            //Just test default float value (double), and exp symbols (e->double, s->single, d -> double)
+            token = parser.ParseInput("123.4 ");
+            CheckType(token, typeof(double));
+            Assert.True(Math.Abs((double)token.Value - 123.4) < eps, "Failed to read double value #1");
+
+            token = parser.ParseInput("1234e-1 ");
+            CheckType(token, typeof(double));
+            Assert.True(Math.Abs((double)token.Value - 1234e-1) < eps, "Failed to read single value #2");
+
+            token = parser.ParseInput("1234s-1 ");
+            CheckType(token, typeof(Single));
+            Assert.True(Math.Abs((Single)token.Value - 1234e-1) < eps, "Failed to read single value #3");
+
+            token = parser.ParseInput("12.34d+01 ");
+            CheckType(token, typeof(double));
+            Assert.True(Math.Abs((double)token.Value - 123.4) < eps, "Failed to read double value  #4");
+        }//method
+
+        [Fact]
+        public void TestNumber_WithUnderscore()
+        {
+            Parser parser; Token token;
+
+            var number = new NumberLiteral("number", NumberOptions.AllowUnderscore);
+            parser = TestHelper.CreateParser(number);
+
+            //Simple integers and suffixes
+            token = parser.ParseInput("1_234_567");
+            CheckType(token, typeof(int));
+            Assert.True((int)token.Value == 1234567, "Failed to read int value with underscores.");
+        }//method
+
+
+        //There was a bug discovered in NumberLiteral - it cannot parse appropriately the int.MinValue value.
+        // This test ensures that the issue is fixed.
+        [Fact]
+        public void TestNumber_MinMaxValues()
+        {
+            Parser parser; Token token;
+
+            var number = new NumberLiteral("number", NumberOptions.AllowSign);
+            number.DefaultIntTypes = new TypeCode[] { TypeCode.Int32 };
+            parser = TestHelper.CreateParser(number);
+            var s = int.MinValue.ToString();
+            token = parser.ParseInput(s);
+            Assert.False(token.IsError(), "Failed to scan int.MinValue, scanner returned an error.");
+            CheckType(token, typeof(int));
+            Assert.True((int)token.Value == int.MinValue, "Failed to scan int.MinValue, scanned value does not match.");
+            s = int.MaxValue.ToString();
+            token = parser.ParseInput(s);
+            Assert.False(token.IsError(), "Failed to scan int.MaxValue, scanner returned an error.");
+            CheckType(token, typeof(int));
+            Assert.True((int)token.Value == int.MaxValue, "Failed to read int.MaxValue");
+        }//method
+
+        private void CheckType(Token token, Type type)
+        {
+            Assert.False(token == null, "TryMatch returned null, while token was expected.");
+            Type vtype = token.Value.GetType();
+            Assert.True(vtype == type, "Invalid target type, expected " + type.ToString() + ", found:  " + vtype);
+        }
+
+
+    }//class
+}//namespace

--- a/src/Irony.Tests/OperatorTests.cs
+++ b/src/Irony.Tests/OperatorTests.cs
@@ -1,0 +1,154 @@
+using Irony.Parsing;
+using Xunit;
+
+namespace Irony.Tests
+{
+    public class OperatorTests
+    {
+
+        #region Grammars
+        public class OperatorGrammar : Grammar
+        {
+            public OperatorGrammar()
+            {
+                var id = new IdentifierTerminal("id");
+                var binOp = new NonTerminal("binOp");
+                var unOp = new NonTerminal("unOp");
+                var expr = new NonTerminal("expr");
+                var binExpr = new NonTerminal("binExpr");
+                var unExpr = new NonTerminal("unExpr");
+
+                base.Root = expr;
+                expr.Rule = id | binExpr | unExpr;
+                binExpr.Rule = expr + binOp + expr;
+                binOp.Rule = ToTerm("+") | "-" | "*" | "/";
+                unExpr.Rule = unOp + expr;
+                unOp.Rule = ToTerm("+") | "-";
+
+                RegisterOperators(10, "+", "-");
+                RegisterOperators(20, "*", "/");
+                MarkTransient(expr, binOp, unOp);
+            }
+        }//operator grammar class
+
+        public class OperatorGrammarHintsOnTerms : Grammar
+        {
+            public OperatorGrammarHintsOnTerms()
+            {
+                var id = new IdentifierTerminal("id");
+                var binOp = new NonTerminal("binOp");
+                var unOp = new NonTerminal("unOp");
+                var expr = new NonTerminal("expr");
+                var binExpr = new NonTerminal("binExpr");
+                var unExpr = new NonTerminal("unExpr");
+
+                base.Root = expr;
+                expr.Rule = id | binExpr | unExpr;
+                binExpr.Rule = expr + binOp + expr;
+                binOp.Rule = ToTerm("+") | "-" | "*" | "/";
+                unExpr.Rule = unOp + expr;
+                var unOpHint = ImplyPrecedenceHere(30); // Force higher precedence than multiplication precedence
+                unOp.Rule = unOpHint + "+" | unOpHint + "-";
+                RegisterOperators(10, "+", "-");
+                RegisterOperators(20, "*", "/");
+                MarkTransient(expr, binOp, unOp);
+            }
+        }//operator grammar class
+
+        public class OperatorGrammarHintsOnNonTerms : Grammar
+        {
+            public OperatorGrammarHintsOnNonTerms()
+            {
+                var id = new IdentifierTerminal("id");
+                var binOp = new NonTerminal("binOp");
+                var unOp = new NonTerminal("unOp");
+                var expr = new NonTerminal("expr");
+                var binExpr = new NonTerminal("binExpr");
+                var unExpr = new NonTerminal("unExpr");
+
+                base.Root = expr;
+                expr.Rule = id | binExpr | unExpr;
+                binExpr.Rule = expr + binOp + expr;
+                binOp.Rule = ToTerm("+") | "-" | "*" | "/";
+                var unOpHint = ImplyPrecedenceHere(30); // Force higher precedence than multiplication precedence
+                unExpr.Rule = unOpHint + unOp + expr;
+                unOp.Rule = ToTerm("+") | "-";
+                RegisterOperators(10, "+", "-");
+                RegisterOperators(20, "*", "/");
+                MarkTransient(expr, binOp, unOp);
+            }
+        }//operator grammar class
+
+        #endregion
+
+        [Fact]
+        public void TestOperatorPrecedence()
+        {
+
+            var grammar = new OperatorGrammar();
+            var parser = new Parser(grammar);
+            TestHelper.CheckGrammarErrors(parser);
+
+            var parseTree = parser.Parse("x + y * z");
+            TestHelper.CheckParseErrors(parseTree);
+            Assert.True(parseTree.Root != null, "Root not found.");
+            Assert.True(parseTree.Root.Term.Name == "binExpr", "Expected binExpr.");
+            Assert.True(parseTree.Root.ChildNodes[1].Term.Name == "+", "Expected + operator."); //check that top operator is "+", not "*"
+
+            parseTree = parser.Parse("x * y + z");
+            TestHelper.CheckParseErrors(parseTree);
+            Assert.True(parseTree.Root != null, "Root not found.");
+            Assert.True(parseTree.Root.Term.Name == "binExpr", "Expected binExpr.");
+            Assert.True(parseTree.Root.ChildNodes[1].Term.Name == "+", "Expected + operator."); //check that top operator is "+", not "*"
+
+            parseTree = parser.Parse("-x * y"); //should be interpreted as -(x*y), so top operator should be -
+            TestHelper.CheckParseErrors(parseTree);
+            Assert.True(parseTree.Root != null, "Root not found.");
+            Assert.True(parseTree.Root.Term.Name == "unExpr", "Expected unExpr.");
+            Assert.True(parseTree.Root.ChildNodes[0].Term.Name == "-", "Expected - operator."); //check that top operator is "+", not "*"
+
+        }
+
+        //These tests check how implied precedence work. We use ImpliedPrecedenceHint to set precedence on unary +,- operators and make it 
+        // higher than binary +,-. We make it even higher than * precedence, so that -x*y is interpreted as '(-x)*y', not like '-(x*y)' 
+        // the second interpretation is chosen when there are no hints.
+        [Fact]
+        public void TestOperatorPrecedenceWithHints()
+        {
+
+            var grammar = new OperatorGrammarHintsOnTerms();
+            var parser = new Parser(grammar);
+            TestHelper.CheckGrammarErrors(parser);
+
+            var parseTree = parser.Parse("x + y * z");
+            TestHelper.CheckParseErrors(parseTree);
+            Assert.True(parseTree.Root != null, "Root not found.");
+            Assert.True(parseTree.Root.Term.Name == "binExpr", "Expected binExpr.");
+            Assert.True(parseTree.Root.ChildNodes[1].Term.Name == "+", "Expected + operator."); //check that top operator is "+", not "*"
+
+            parseTree = parser.Parse("-x * y"); //should be interpreted as (-x)*y, so top operator should be *
+            TestHelper.CheckParseErrors(parseTree);
+            Assert.True(parseTree.Root != null, "Root not found.");
+            Assert.True(parseTree.Root.Term.Name == "binExpr", "Expected binExpr.");
+            Assert.True(parseTree.Root.ChildNodes[1].Term.Name == "*", "Expected * operator."); //check that top operator is "+", not "*"
+
+            var grammar2 = new OperatorGrammarHintsOnNonTerms();
+            parser = new Parser(grammar2);
+            TestHelper.CheckGrammarErrors(parser);
+
+            parseTree = parser.Parse("x + y * z");
+            TestHelper.CheckParseErrors(parseTree);
+            Assert.True(parseTree.Root != null, "Root not found.");
+            Assert.True(parseTree.Root.Term.Name == "binExpr", "Expected binExpr.");
+            Assert.True(parseTree.Root.ChildNodes[1].Term.Name == "+", "Expected + operator."); //check that top operator is "+", not "*"
+
+            parseTree = parser.Parse("-x*y"); //should be interpreted as (-x)*y, so top operator should be *
+            TestHelper.CheckParseErrors(parseTree);
+            Assert.True(parseTree.Root != null, "Root not found.");
+            Assert.True(parseTree.Root.Term.Name == "binExpr", "Expected binExpr.");
+            Assert.True(parseTree.Root.ChildNodes[1].Term.Name == "*", "Expected * operator."); //check that top operator is "+", not "*"
+
+        }
+
+    }//class
+}//namespace

--- a/src/Irony.Tests/RegExLiteralTests.cs
+++ b/src/Irony.Tests/RegExLiteralTests.cs
@@ -1,0 +1,30 @@
+using Irony.Parsing;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Irony.Tests
+{
+
+    public class RegexLiteralTests
+    {
+
+        //The following test method and a fix are contributed by ashmind codeplex user
+        [Fact]
+        public void TestRegExLiteral()
+        {
+            Parser parser; Token token;
+
+            var term = new RegexLiteral("RegEx");
+            parser = TestHelper.CreateParser(term);
+            token = parser.ParseInput(@"/abc\\\/de/gm  ");
+            Assert.False(token == null, "Failed to produce a token on valid string.");
+            Assert.True(term == token.Terminal, "Failed to scan a string - invalid Terminal in the returned token.");
+            Assert.False(token.Value == null, "Token Value field is null - should be Regex object.");
+            var regex = token.Value as Regex;
+            Assert.False(regex == null, "Failed to create Regex object.");
+            var match = regex.Match(@"00abc\/de00");
+            Assert.True(match.Index == 2, "Failed to match a regular expression");
+        }
+
+    }//class
+}//namespace

--- a/src/Irony.Tests/StringLiteralTests.cs
+++ b/src/Irony.Tests/StringLiteralTests.cs
@@ -1,0 +1,138 @@
+using Irony.Parsing;
+using Xunit;
+
+namespace Irony.Tests
+{
+
+    public class StringLiteralTests  {
+
+
+    //handy option for stringLiteral tests: we use single quotes in test strings, and they are replaced by double quotes here 
+    private static string ReplaceQuotes(string input) {
+      return input.Replace("'", "\"");
+    }
+
+    //The following test method and a fix are contributed by ashmind codeplex user
+    [Fact]
+    public void TestString_QuoteJustBeforeEof() {
+      Parser parser; Token token;
+
+      parser = TestHelper.CreateParser(new StringLiteral("String", "'"));
+      token = parser.ParseInput(@"'");
+      Assert.True(TokenCategory.Error == token.Terminal.Category, "Incorrect string was not parsed as syntax error.");
+    }
+
+
+    [Fact]
+    public void TestString_Python() {
+      Parser parser; Token token;
+
+      parser = TestHelper.CreateParser(TerminalFactory.CreatePythonString("String"));
+      //1. Single quotes
+      token = parser.ParseInput(@"'00\a\b\t\n\v\f\r\'\\00'  ");
+      Assert.True((string)token.Value == "00\a\b\t\n\v\f\r\'\\00", "Failed to process escaped characters.");
+      token = parser.ParseInput("'abcd\nefg'  ");
+      Assert.True(token.IsError(), "Failed to detect erroneous multi-line string.");
+      token = parser.ParseInput("'''abcd\nefg'''  ");
+      Assert.True((string)token.Value == "abcd\nefg", "Failed to process line break in triple-quote string.");
+      token = parser.ParseInput(@"'''abcd\" + "\n" + "efg'''  ");
+      Assert.True((string)token.Value == "abcd\nefg", "Failed to process escaped line-break char.");
+      token = parser.ParseInput(@"r'00\a\b\t\n\v\f\r00'  ");
+      Assert.True((string)token.Value == @"00\a\b\t\n\v\f\r00", "Failed to process string with disabled escapes.");
+      
+      //2. Double quotes - we use TryMatchDoubles which replaces single quotes with doubles and then calls TryMatch
+      token = parser.ParseInput(ReplaceQuotes(@"'00\a\b\t\n\v\f\r\'\\00'  "));
+      Assert.True((string)token.Value == "00\a\b\t\n\v\f\r\"\\00", "Failed to process escaped characters.");
+      token = parser.ParseInput(ReplaceQuotes("'abcd\nefg'  "));
+      Assert.True(token.IsError(), "Failed to detect erroneous multi-line string. (Double quotes)");
+      token = parser.ParseInput(ReplaceQuotes("'''abcd\nefg'''  "));
+      Assert.True((string)token.Value == "abcd\nefg", "Failed to process line break in triple-quote string. (Double quotes)");
+      token = parser.ParseInput(ReplaceQuotes(@"'''abcd\" + "\n" + "efg'''  "));
+      Assert.True((string)token.Value == "abcd\nefg", "Failed to process escaped line-break char. (Double quotes)");
+      token = parser.ParseInput(ReplaceQuotes(@"r'00\a\b\t\n\v\f\r00'  "));
+      Assert.True((string)token.Value == @"00\a\b\t\n\v\f\r00", "Failed to process string with disabled escapes. (Double quotes)");
+    }//method
+
+    [Fact]
+    public void TestString_CSharp() {
+      Parser parser; Token token;
+
+      parser = TestHelper.CreateParser(TerminalFactory.CreateCSharpString("String"));
+
+      token = parser.ParseInput('"' + @"abcd\\" + '"' + "  ");
+      Assert.True((string)token.Value == @"abcd\", "Failed to process double escape char at the end of the string.");
+
+      token = parser.ParseInput('"' + @"abcd\\\" + '"' + "efg" + '"' + "   ");
+      Assert.True((string)token.Value == @"abcd\" + '"' + "efg" , @"Failed to process '\\\ + double-quote' inside the string.");
+
+      //with Escapes
+      token = parser.ParseInput(ReplaceQuotes(@"'00\a\b\t\n\v\f\r\'\\00'  "));
+      Assert.True((string)token.Value == "00\a\b\t\n\v\f\r\"\\00", "Failed to process escaped characters.");
+      token = parser.ParseInput(ReplaceQuotes("'abcd\nefg'  "));
+      Assert.True(token.IsError(), "Failed to detect erroneous multi-line string.");
+      //with disabled escapes
+      token = parser.ParseInput(ReplaceQuotes(@"@'00\a\b\t\n\v\f\r00'  "));
+      Assert.True((string)token.Value == @"00\a\b\t\n\v\f\r00", "Failed to process @-string with disabled escapes.");
+      token = parser.ParseInput(ReplaceQuotes("@'abc\ndef'  "));
+      Assert.True((string)token.Value == "abc\ndef", "Failed to process @-string with linebreak.");
+      //Unicode and hex
+      token = parser.ParseInput(ReplaceQuotes(@"'abc\u0040def'  "));
+      Assert.True((string)token.Value == "abc@def", "Failed to process unicode escape \\u.");
+      token = parser.ParseInput(ReplaceQuotes(@"'abc\U00000040def'  "));
+      Assert.True((string)token.Value == "abc@def", "Failed to process unicode escape \\u.");
+      token = parser.ParseInput(ReplaceQuotes(@"'abc\x0040xyz'  "));
+      Assert.True((string)token.Value == "abc@xyz", "Failed to process hex escape (4 digits).");
+      token = parser.ParseInput(ReplaceQuotes(@"'abc\x040xyz'  "));
+      Assert.True((string)token.Value == "abc@xyz", "Failed to process hex escape (3 digits).");
+      token = parser.ParseInput(ReplaceQuotes(@"'abc\x40xyz'  "));
+      Assert.True((string)token.Value == "abc@xyz", "Failed to process hex escape (2 digits).");
+      //octals
+      token = parser.ParseInput(ReplaceQuotes(@"'abc\0601xyz'  ")); //the last digit "1" should not be included in octal number
+      Assert.True((string)token.Value == "abc01xyz", "Failed to process octal escape (3 + 1 digits).");
+      token = parser.ParseInput(ReplaceQuotes(@"'abc\060xyz'  "));
+      Assert.True((string)token.Value == "abc0xyz", "Failed to process octal escape (3 digits).");
+      token = parser.ParseInput(ReplaceQuotes(@"'abc\60xyz'  "));
+      Assert.True((string)token.Value == "abc0xyz", "Failed to process octal escape (2 digits).");
+      token = parser.ParseInput(ReplaceQuotes(@"'abc\0xyz'  "));
+      Assert.True((string)token.Value == "abc\0xyz", "Failed to process octal escape (1 digit).");
+    }
+
+    [Fact]
+    public void TestString_CSharpChar() {
+      Parser parser; Token token;
+
+      parser = TestHelper.CreateParser(TerminalFactory.CreateCSharpChar("Char"));
+      token = parser.ParseInput("'a'  ");
+      Assert.True((char)token.Value == 'a', "Failed to process char.");
+      token = parser.ParseInput(@"'\n'  ");
+      Assert.True((char)token.Value == '\n', "Failed to process new-line char.");
+      token = parser.ParseInput(@"''  ");
+      Assert.True(token.IsError(), "Failed to recognize empty quotes as invalid char literal.");
+      token = parser.ParseInput(@"'abc'  ");
+      Assert.True(token.IsError(), "Failed to recognize multi-char sequence as invalid char literal.");
+      //Note: unlike strings, c# char literals don't allow the "@" prefix
+    }
+
+    [Fact]
+    public void TestString_VB() {
+      Parser parser; Token token;
+
+      parser = TestHelper.CreateParser(TerminalFactory.CreateVbString("String"));
+      //VB has no escapes - so make sure term doesn't catch any escapes
+      token = parser.ParseInput(ReplaceQuotes(@"'00\a\b\t\n\v\f\r\\00'  "));
+      Assert.True((string)token.Value == @"00\a\b\t\n\v\f\r\\00", "Failed to process string with \\ characters.");
+      token = parser.ParseInput(ReplaceQuotes("'abcd\nefg'  "));
+      Assert.True(token.IsError(), "Failed to detect erroneous multi-line string.");
+      token = parser.ParseInput(ReplaceQuotes("'abcd''efg'  ")); 
+      Assert.True((string)token.Value == "abcd\"efg", "Failed to process a string with doubled double-quote char.");
+      //Test char suffix "c"
+      token = parser.ParseInput(ReplaceQuotes("'A'c  ")); 
+      Assert.True((char)token.Value == 'A', "Failed to process a character");
+      token = parser.ParseInput(ReplaceQuotes("''c  "));
+      Assert.True(token.IsError(), "Failed to detect an error for an empty char.");
+      token = parser.ParseInput(ReplaceQuotes("'ab'C  "));
+      Assert.True(token.IsError(), "Failed to detect error in multi-char sequence.");
+    }
+
+  }//class
+}//namespace

--- a/src/Irony.Tests/TestHelper.cs
+++ b/src/Irony.Tests/TestHelper.cs
@@ -1,0 +1,72 @@
+﻿using Irony.Parsing;
+using System;
+using Xunit;
+
+namespace Irony.Tests
+{
+
+    public static class TestHelper
+    {
+        //A skeleton for a grammar with a single terminal, followed by optional terminator
+        class TerminalTestGrammar : Grammar
+        {
+            public string Terminator;
+            public TerminalTestGrammar(Terminal terminal, string terminator = null) : base(caseSensitive: true)
+            {
+                Terminator = terminator;
+                var rule = new BnfExpression(terminal);
+                if (Terminator != null)
+                {
+                    MarkReservedWords(Terminator);
+                    rule += Terminator;
+                }
+                base.Root = new NonTerminal("Root");
+                Root.Rule = rule;
+            }
+
+        }//class
+
+        public static Parser CreateParser(Terminal terminal, string terminator = "end")
+        {
+            var grammar = new TerminalTestGrammar(terminal, terminator);
+            var parser = new Parser(grammar);
+            CheckGrammarErrors(parser);
+            return parser;
+        }
+
+        public static void CheckGrammarErrors(Parser parser)
+        {
+            var errors = parser.Language.Errors;
+            if (errors.Count > 0)
+                throw new Exception("Unexpected grammar contains error(s): " + string.Join("\n", errors));
+        }
+        public static void CheckParseErrors(ParseTree parseTree)
+        {
+            if (parseTree.HasErrors())
+                throw new Exception("Unexpected parse error(s): " + string.Join("\n", parseTree.ParserMessages));
+        }
+
+        public static Token ParseInput(this Parser parser, string input, bool useTerminator = true)
+        {
+            var g = (TerminalTestGrammar)parser.Language.Grammar;
+            useTerminator &= g.Terminator != null;
+            if (useTerminator)
+                input += " " + g.Terminator;
+            var tree = parser.Parse(input);
+            //If error, then return this error token, this is probably what is expected.
+            var first = tree.Tokens[0];
+            if (first.IsError())
+                return first;
+            //Verify that last or before-last token is a terminator
+            if (useTerminator)
+            {
+                Assert.True(tree.Tokens.Count >= 2, "Wrong # of tokens - expected at least 2. Input: " + input);
+                var count = tree.Tokens.Count;
+                //The last is EOF, the one before last should be a terminator
+                Assert.True(g.Terminator == tree.Tokens[count - 2].Text, "Input terminator not found in the second token. Input: " + input);
+            }
+            return tree.Tokens[0];
+        }
+
+    }//class
+}

--- a/src/Irony.Tests/TokenPreviewResolution/ConflictGrammars.cs
+++ b/src/Irony.Tests/TokenPreviewResolution/ConflictGrammars.cs
@@ -1,0 +1,120 @@
+using Irony.Parsing;
+
+namespace Irony.Tests.TokenPreviewResolution
+{
+
+    [Language("Grammar with conflicts, no hints", "1.1", "Grammar with conflicts, no hints.")]
+    public class ConflictGrammarNoHints : Grammar
+    {
+        public ConflictGrammarNoHints()
+          : base(true)
+        {
+            var name = new IdentifierTerminal("id");
+
+            var stmt = new NonTerminal("Statement");
+            var stmtList = new NonTerminal("StatementList");
+            var fieldModifier = new NonTerminal("fieldModifier");
+            var propModifier = new NonTerminal("propModifier");
+            var methodModifier = new NonTerminal("methodModifier");
+            var fieldModifierList = new NonTerminal("fieldModifierList");
+            var propModifierList = new NonTerminal("propModifierList");
+            var methodModifierList = new NonTerminal("methodModifierList");
+            var fieldDef = new NonTerminal("fieldDef");
+            var propDef = new NonTerminal("propDef");
+            var methodDef = new NonTerminal("methodDef");
+
+            //Rules
+            this.Root = stmtList;
+            stmtList.Rule = MakePlusRule(stmtList, stmt);
+            stmt.Rule = fieldDef | propDef | methodDef;
+            fieldDef.Rule = fieldModifierList + name + name + ";";
+            propDef.Rule = propModifierList + name + name + "{" + "}";
+            methodDef.Rule = methodModifierList + name + name + "(" + ")" + "{" + "}";
+            fieldModifierList.Rule = MakeStarRule(fieldModifierList, fieldModifier);
+            propModifierList.Rule = MakeStarRule(propModifierList, propModifier);
+            methodModifierList.Rule = MakeStarRule(methodModifierList, methodModifier);
+
+            // That's the key of the problem: 3 modifiers have common members
+            //   so parser automaton has hard time deciding which modifiers list to produce - 
+            //   is it a field, prop or method we are beginning to parse?
+            fieldModifier.Rule = ToTerm("public") | "private" | "readonly" | "volatile";
+            propModifier.Rule = ToTerm("public") | "private" | "readonly" | "override";
+            methodModifier.Rule = ToTerm("public") | "private" | "override";
+
+            MarkReservedWords("public", "private", "readonly", "volatile", "override");
+        }
+    }
+
+    [Language("Grammar with conflicts #2", "1.1", "Conflict grammar with hints added to productions.")]
+    public class ConflictGrammarWithHintsInRules : Grammar
+    {
+        public ConflictGrammarWithHintsInRules() : base(true)
+        {
+            var name = new IdentifierTerminal("id");
+
+            var definition = new NonTerminal("definition");
+            var fieldDef = new NonTerminal("fieldDef");
+            var propDef = new NonTerminal("propDef");
+            var fieldModifier = new NonTerminal("fieldModifier");
+            var propModifier = new NonTerminal("propModifier");
+
+            definition.Rule = fieldDef | propDef;
+            fieldDef.Rule = fieldModifier + name + name + ";";
+            propDef.Rule = propModifier + name + name + "{" + "}";
+            var fieldHint = ReduceIf(";", comesBefore: "{");
+            fieldModifier.Rule = "public" + fieldHint | "private" + fieldHint | "readonly";
+            propModifier.Rule = ToTerm("public") | "private" | "override";
+
+            Root = definition;
+        }
+    }//class
+
+    [Language("Grammar with conflicts #4", "1.1", "Test conflict grammar with conflicts and hints: hints are added to non-terminals.")]
+    public class ConflictGrammarWithHintsOnTerms : Grammar
+    {
+        public ConflictGrammarWithHintsOnTerms()
+          : base(true)
+        {
+            var name = new IdentifierTerminal("id");
+
+            var stmt = new NonTerminal("Statement");
+            var stmtList = new NonTerminal("StatementList");
+            var fieldModifier = new NonTerminal("fieldModifier");
+            var propModifier = new NonTerminal("propModifier");
+            var methodModifier = new NonTerminal("methodModifier");
+            var fieldModifierList = new NonTerminal("fieldModifierList");
+            var propModifierList = new NonTerminal("propModifierList");
+            var methodModifierList = new NonTerminal("methodModifierList");
+            var fieldDef = new NonTerminal("fieldDef");
+            var propDef = new NonTerminal("propDef");
+            var methodDef = new NonTerminal("methodDef");
+
+            //Rules
+            this.Root = stmtList;
+            stmtList.Rule = MakePlusRule(stmtList, stmt);
+            stmt.Rule = fieldDef | propDef | methodDef;
+            fieldDef.Rule = fieldModifierList + name + name + ";";
+            propDef.Rule = propModifierList + name + name + "{" + "}";
+            methodDef.Rule = methodModifierList + name + name + "(" + ")" + "{" + "}";
+            fieldModifierList.Rule = MakeStarRule(fieldModifierList, fieldModifier);
+            propModifierList.Rule = MakeStarRule(propModifierList, propModifier);
+            methodModifierList.Rule = MakeStarRule(methodModifierList, methodModifier);
+
+            fieldModifier.Rule = ToTerm("public") | "private" | "readonly" | "volatile";
+            propModifier.Rule = ToTerm("public") | "private" | "readonly" | "override";
+            methodModifier.Rule = ToTerm("public") | "private" | "override";
+
+            // conflict resolution
+            var fieldHint = new TokenPreviewHint(PreferredActionType.Reduce, thisSymbol: ";", comesBefore: new string[] { "(", "{" });
+            fieldModifier.AddHintToAll(fieldHint);
+            fieldModifierList.AddHintToAll(fieldHint);
+            var propHint = new TokenPreviewHint(PreferredActionType.Reduce, thisSymbol: "{", comesBefore: new string[] { ";", "(" });
+            propModifier.AddHintToAll(propHint);
+            propModifierList.AddHintToAll(propHint);
+
+            MarkReservedWords("public", "private", "readonly", "volatile", "override");
+        }
+    }
+
+
+}

--- a/src/Irony.Tests/TokenPreviewResolution/ConflictResolutionTests.cs
+++ b/src/Irony.Tests/TokenPreviewResolution/ConflictResolutionTests.cs
@@ -1,0 +1,113 @@
+using Irony.Parsing;
+using System.Linq;
+using Xunit;
+
+namespace Irony.Tests.TokenPreviewResolution
+{
+
+    public class ConflictResolutionTests {
+
+    // samples to be parsed
+    const string FieldSample = "private int SomeField;";
+    const string PropertySample = "public string Name {}";
+    const string FieldListSample = "private int Field1; public string Field2;";
+  const string MixedListSample = @"
+      public int Size {}
+      private string TableName;
+      override void Run()
+      {
+      }";
+
+    // Full grammar, no hints - expect errors ---------------------------------------------------------------------
+    [Fact]
+    public void TestConflictGrammarNoHints_HasErrors() {
+      var grammar = new ConflictGrammarNoHints();
+      var parser = new Parser(grammar);
+      Assert.True(parser.Language.Errors.Count > 0);
+      //Cannot parse mixed list
+      var sample = MixedListSample;
+      var tree = parser.Parse(sample);
+      Assert.NotNull(tree);
+      Assert.True(tree.HasErrors());
+    }
+
+    // Hints in Rules --------------------------------------------------------------------------
+    [Fact]
+    public void TestConflictGrammarWithHintsOnRules() {
+      var grammar = new ConflictGrammarWithHintsInRules();
+      var parser = new Parser(grammar);
+      Assert.True(parser.Language.Errors.Count == 0);
+      // Field sample
+      var sample = FieldSample;
+      var tree = parser.Parse(sample);
+      Assert.NotNull(tree);
+      Assert.False(tree.HasErrors());
+
+      Assert.NotNull(tree.Root);
+      var term = tree.Root.Term as NonTerminal;
+      Assert.NotNull(term);
+      Assert.Equal("definition", term.Name);
+
+      Assert.Equal(1, tree.Root.ChildNodes.Count);
+      var modNode = tree.Root.ChildNodes[0].ChildNodes[0];
+      Assert.Equal("fieldModifier", modNode.Term.Name);
+
+      //Property 
+      sample = PropertySample;
+      tree = parser.Parse(sample);
+      Assert.NotNull(tree);
+      Assert.False(tree.HasErrors());
+
+      Assert.NotNull(tree.Root);
+      term = tree.Root.Term as NonTerminal;
+      Assert.NotNull(term);
+      Assert.Equal("definition", term.Name);
+
+      Assert.Equal(1, tree.Root.ChildNodes.Count);
+      modNode = tree.Root.ChildNodes[0].ChildNodes[0];
+      Assert.Equal("propModifier", modNode.Term.Name);
+    }
+
+    //Hints on terms ---------------------------------------------------------------------
+    [Fact]
+    public void TestConflictGrammar_HintsOnTerms() {
+      var grammar = new ConflictGrammarWithHintsOnTerms();
+      var parser = new Parser(grammar);
+      Assert.True(parser.Language.Errors.Count == 0);
+
+      //Field list sample
+      var sample = FieldListSample;
+      var tree = parser.Parse(sample);
+      Assert.NotNull(tree);
+      Assert.False(tree.HasErrors());
+
+      Assert.NotNull(tree.Root);
+      var term = tree.Root.Term as NonTerminal;
+      Assert.NotNull(term);
+      Assert.Equal("StatementList", term.Name);
+
+      Assert.Equal(2, tree.Root.ChildNodes.Count);
+      var nodes = tree.Root.ChildNodes.Select(t => t.ChildNodes[0]).ToArray();
+      Assert.Equal("fieldDef", nodes[0].Term.Name);
+      Assert.Equal("fieldDef", nodes[1].Term.Name);
+
+      //Mixed sample
+      sample = MixedListSample;
+      tree = parser.Parse(sample);
+      Assert.NotNull(tree);
+      Assert.False(tree.HasErrors());
+
+      Assert.NotNull(tree.Root);
+      term = tree.Root.Term as NonTerminal;
+      Assert.NotNull(term);
+      Assert.Equal("StatementList", term.Name);
+
+      Assert.Equal(3, tree.Root.ChildNodes.Count);
+      nodes = tree.Root.ChildNodes.Select(t => t.ChildNodes[0]).ToArray();
+      Assert.Equal("propDef", nodes[0].Term.Name);
+      Assert.Equal("fieldDef", nodes[1].Term.Name);
+      Assert.Equal("methodDef", nodes[2].Term.Name);
+    }
+
+  }
+}


### PR DESCRIPTION
Here are the original unit tests converted to XUnit. I tried to keep as identical to originals as possible as a baseline. As noted below, two of the tests currently fail with Reflection exceptions - I have not investigated these yet other than to place TODO comments by the offending lines.
Those tests are:
- EvaluatorTests.TestEvaluator_BuiltIns
- EvaluatorTests.TestEvaluator_MemberAccess

Original commit details below...
=======================================
Added Tests project based on a copy of unit tests from Codeplex project converted to XUnit tests. Attempted to leave tests as-is as much as possible, but a few minor changes were needed to accomodate switching to XUnit.

- Tests currently run on netcoreapp1.1
- Two tests currently throw System.Reflection.AmbiguousMatchException
- Removed the Heredoc tests, since those were not run in the original project anyway.