### PR TITLE
Allow custom Operation Handlers

### DIFF
--- a/src/Irony.Interpreter/InterpretedLanguageGrammar.cs
+++ b/src/Irony.Interpreter/InterpretedLanguageGrammar.cs
@@ -52,8 +52,12 @@ namespace Irony.Interpreter {
       return new LanguageRuntime(language); 
     }
 
+    public virtual OperatorHandler CreateOpeartorHandler(LanguageData language) {
+        return new OperatorHandler(language.Grammar.CaseSensitive);
+    }
+
     public override void BuildAst(LanguageData language, ParseTree parseTree) {
-      var opHandler = new OperatorHandler(language.Grammar.CaseSensitive);
+      var opHandler = CreateOpeartorHandler(language);
       Util.Check(!parseTree.HasErrors(), "ParseTree has errors, cannot build AST.");
       var astContext = new InterpreterAstContext(language, opHandler);
       var astBuilder = new AstBuilder(astContext);


### PR DESCRIPTION
Upgrading an old project that used the old Codeplex version of Irony I find out you aren't any more able to change the Operation Handler.

Even if you change the Evaluator one a new one is still created by the Interpreted Grammar here. 

This small change allows an easy implementation of  custom Operation Handler without needing to override the whole BuildAst method.